### PR TITLE
Update README.md to reflect new OPF repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You'll also need TCP/IP port 2020 free on your local machine.
 
 First clone this repository, if you've not already done so, and move into your local directory copy:
 ```
-git clone git@github.com:openplanets/scape-demo-sites.git
+git clone git@github.com:openpreserve/scape-demo-sites.git
 cd scape-demo-sites
 ```
 


### PR DESCRIPTION
changed the installation section to reflect the new link (git clone git@github.com:openpreserve/scape-demo-sites.git from git clone git@github.com:openplanets/scape-demo-sites.git)